### PR TITLE
Inferno - mager flickering effect

### DIFF
--- a/src/content/inferno/js/JalZekModelWithLight.ts
+++ b/src/content/inferno/js/JalZekModelWithLight.ts
@@ -12,13 +12,13 @@ import { JalZek } from "./mobs/JalZek";
 export class JalZekModelWithLight extends GLTFModel {
   underglowLight: THREE.PointLight | null = null;
   jalZekRenderable: JalZek;
-   lightParented = false;
- primaryModelPath: string;
+  lightParented = false;
+  primaryModelPath: string;
 
   // light props
   readonly NORMAL_UNDERGLOW_INTENSITY: number = 32.0;
-   readonly FLICKER_OFF_INTENSITY: number = 0.05;
-   readonly FLICKER_ON_INTENSITY: number = 64.0;
+  readonly FLICKER_OFF_INTENSITY: number = 0.05;
+  readonly FLICKER_ON_INTENSITY: number = 50.0;
 
   constructor(renderable: JalZek, modelPath: string, options?: GLTFModelOptions) {
     super(renderable, [modelPath], options || {});
@@ -31,7 +31,8 @@ export class JalZekModelWithLight extends GLTFModel {
     this.underglowLight = new THREE.PointLight(
       0xFF0000, // red
       this.NORMAL_UNDERGLOW_INTENSITY,
-      this.jalZekRenderable.size * 16.0 // MAXXING OUT!!
+      this.jalZekRenderable.size * 3.0, // reduced radius
+      7 // increased decay for sharper falloff
     );
     this.underglowLight.position.set(0, -1.0, 0);
     this.underglowLight.visible = true;

--- a/src/content/inferno/js/JalZekModelWithLight.ts
+++ b/src/content/inferno/js/JalZekModelWithLight.ts
@@ -29,7 +29,7 @@ export class JalZekModelWithLight extends GLTFModel {
 
   private createLight() {
     this.underglowLight = new THREE.PointLight(
-      0x00FFFF, // neon cyan currently to stand out (not sure how to override the existing red  underglow thing) xd
+      0xFF0000, // red
       this.NORMAL_UNDERGLOW_INTENSITY,
       this.jalZekRenderable.size * 16.0 // MAXXING OUT!!
     );

--- a/src/content/inferno/js/JalZekModelWithLight.ts
+++ b/src/content/inferno/js/JalZekModelWithLight.ts
@@ -1,0 +1,113 @@
+import {
+  Assets,
+  GLTFModel,
+  Model,
+  Location3,
+  Renderable,
+  GLTFModelOptions
+} from "@supalosa/oldschool-trainer-sdk";
+import * as THREE from "three";
+import { JalZek } from "./mobs/JalZek";
+
+export class JalZekModelWithLight extends GLTFModel {
+  underglowLight: THREE.PointLight | null = null;
+  jalZekRenderable: JalZek;
+   lightParented = false;
+ primaryModelPath: string;
+
+  // light props
+  readonly NORMAL_UNDERGLOW_INTENSITY: number = 32.0;
+   readonly FLICKER_OFF_INTENSITY: number = 0.05;
+   readonly FLICKER_ON_INTENSITY: number = 64.0;
+
+  constructor(renderable: JalZek, modelPath: string, options?: GLTFModelOptions) {
+    super(renderable, [modelPath], options || {});
+    this.jalZekRenderable = renderable;
+    this.primaryModelPath = modelPath;
+    this.createLight();
+  }
+
+  private createLight() {
+    this.underglowLight = new THREE.PointLight(
+      0x00FFFF, // neon cyan currently to stand out (not sure how to override the existing red  underglow thing) xd
+      this.NORMAL_UNDERGLOW_INTENSITY,
+      this.jalZekRenderable.size * 16.0 // MAXXING OUT!!
+    );
+    this.underglowLight.position.set(0, -1.0, 0);
+    this.underglowLight.visible = true;
+    this.underglowLight.name = `JalZekUnderglow_${this.jalZekRenderable.mobId}`;
+  }
+
+  override async preload(): Promise<void> {
+    await super.preload();
+  }
+
+  override draw(
+    scene: THREE.Scene,
+    clockDelta: number,
+    tickPercent: number,
+    location: Location3,
+    rotation: number,
+    pitch: number,
+    modelIsVisible: boolean,
+    modelOffsets: Location3[]
+  ): void {
+    super.draw(scene, clockDelta, tickPercent, location, rotation, pitch, modelIsVisible, modelOffsets);
+
+    if (modelIsVisible && this.underglowLight && !this.lightParented) {
+      if (this.primaryModelPath) {
+        const sdkModelObject = scene.getObjectByName(this.primaryModelPath);
+        if (sdkModelObject) {
+          sdkModelObject.add(this.underglowLight);
+          this.lightParented = true;
+        }
+      }
+    }
+    if (this.underglowLight) {
+      this.underglowLight.visible = modelIsVisible;
+    }
+  }
+
+  public setFlickerVisualState(isFlickering: boolean): void {
+    if (this.underglowLight) {
+      if (isFlickering) {
+        // Double flicker: ON -> OFF -> ON -> OFF -> normal
+        this.underglowLight.intensity = this.FLICKER_ON_INTENSITY;
+        setTimeout(() => {
+          if (this.underglowLight) {
+            this.underglowLight.intensity = this.FLICKER_OFF_INTENSITY;
+            setTimeout(() => {
+              if (this.underglowLight) {
+                this.underglowLight.intensity = this.FLICKER_ON_INTENSITY;
+                setTimeout(() => {
+                  if (this.underglowLight) {
+                    this.underglowLight.intensity = this.FLICKER_OFF_INTENSITY;
+                    setTimeout(() => {
+                      if (this.underglowLight) {
+                        this.underglowLight.intensity = this.NORMAL_UNDERGLOW_INTENSITY;
+                      }
+                    }, 50);
+                  }
+                }, 50);
+              }
+            }, 50);
+          }
+        }, 50);
+      } else {
+        this.underglowLight.intensity = this.NORMAL_UNDERGLOW_INTENSITY;
+      }
+    }
+  }
+
+  override destroy(scene: THREE.Scene): void {
+    if (this.underglowLight) {
+      if (this.underglowLight.parent) {
+        this.underglowLight.parent.remove(this.underglowLight);
+      }
+      this.underglowLight.dispose();
+      this.underglowLight = null;
+    }
+    this.lightParented = false;
+    super.destroy(scene);
+  }
+} 

--- a/src/content/inferno/js/JalZekModelWithLight.ts
+++ b/src/content/inferno/js/JalZekModelWithLight.ts
@@ -1,11 +1,4 @@
-import {
-  Assets,
-  GLTFModel,
-  Model,
-  Location3,
-  Renderable,
-  GLTFModelOptions
-} from "@supalosa/oldschool-trainer-sdk";
+import { Assets, GLTFModel, Model, Location3, Renderable, GLTFModelOptions } from "@supalosa/oldschool-trainer-sdk";
 import * as THREE from "three";
 import { JalZek } from "./mobs/JalZek";
 
@@ -29,10 +22,10 @@ export class JalZekModelWithLight extends GLTFModel {
 
   private createLight() {
     this.underglowLight = new THREE.PointLight(
-      0xFF0000, // red
+      0xff0000, // red
       this.NORMAL_UNDERGLOW_INTENSITY,
       this.jalZekRenderable.size * 3.0, // reduced radius
-      7 // increased decay for sharper falloff
+      7, // increased decay for sharper falloff
     );
     this.underglowLight.position.set(0, -1.0, 0);
     this.underglowLight.visible = true;
@@ -51,7 +44,7 @@ export class JalZekModelWithLight extends GLTFModel {
     rotation: number,
     pitch: number,
     modelIsVisible: boolean,
-    modelOffsets: Location3[]
+    modelOffsets: Location3[],
   ): void {
     super.draw(scene, clockDelta, tickPercent, location, rotation, pitch, modelIsVisible, modelOffsets);
 
@@ -111,4 +104,4 @@ export class JalZekModelWithLight extends GLTFModel {
     this.lightParented = false;
     super.destroy(scene);
   }
-} 
+}

--- a/src/content/inferno/js/mobs/JalZek.ts
+++ b/src/content/inferno/js/mobs/JalZek.ts
@@ -1,6 +1,22 @@
 "use strict";
 
-import { Assets, Mob, Projectile, MeleeWeapon, MagicWeapon, Sound, UnitBonuses, Collision, AttackIndicators, Random, Viewport, GLTFModel, EntityNames, Trainer, Model } from "@supalosa/oldschool-trainer-sdk";
+import {
+  Assets,
+  Mob,
+  Projectile,
+  MeleeWeapon,
+  MagicWeapon,
+  Sound,
+  UnitBonuses,
+  Collision,
+  AttackIndicators,
+  Random,
+  Viewport,
+  GLTFModel,
+  EntityNames,
+  Trainer,
+  Model,
+} from "@supalosa/oldschool-trainer-sdk";
 
 import { InfernoMobDeathStore } from "../InfernoMobDeathStore";
 import { InfernoRegion } from "../InfernoRegion";
@@ -16,11 +32,11 @@ export const MageProjectileModel = Assets.getAssetUrl("models/mage_projectile.gl
 
 export class JalZek extends Mob {
   shouldRespawnMobs: boolean;
-   isFlickering = false;
-   // flicker only the tick before the attack animation happns
-   flickerDurationTicks = 1; 
-   flickerTicksRemaining = 0;
-   extendedGltfModelInstance: JalZekModelWithLight | null = null;
+  isFlickering = false;
+  // flicker only the tick before the attack animation happns
+  flickerDurationTicks = 1;
+  flickerTicksRemaining = 0;
+  extendedGltfModelInstance: JalZekModelWithLight | null = null;
 
   mobName() {
     return EntityNames.JAL_ZEK;
@@ -153,30 +169,30 @@ export class JalZek extends Mob {
     return { x: 21, y: 22 };
   }
 
-   create3dModel() {
+  create3dModel() {
     if (!this.extendedGltfModelInstance) {
       this.extendedGltfModelInstance = new JalZekModelWithLight(this, MagerModel);
     }
     return this.extendedGltfModelInstance;
   }
 
-   updateUnderglowVisuals() {
+  updateUnderglowVisuals() {
     if (this.extendedGltfModelInstance) {
       this.extendedGltfModelInstance.setFlickerVisualState(this.isFlickering);
     }
   }
 
-   attackStep() {
+  attackStep() {
     super.attackStep();
 
     if (this.isFlickering) {
       this.flickerTicksRemaining--;
       // double flicker on the flicker tick
-      this.extendedGltfModelInstance?.setFlickerVisualState(true); 
+      this.extendedGltfModelInstance?.setFlickerVisualState(true);
       if (this.flickerTicksRemaining <= 0) {
         this.isFlickering = false;
         // reset to normal
-        this.extendedGltfModelInstance?.setFlickerVisualState(false); 
+        this.extendedGltfModelInstance?.setFlickerVisualState(false);
         // Set attack style before attacking
         this.attackStyle = this.attackStyleForNewAttack();
         this.attackFeedback = AttackIndicators.NONE;
@@ -211,7 +227,7 @@ export class JalZek extends Mob {
     this.attackIfPossible();
   }
 
-   attackIfPossible() {
+  attackIfPossible() {
     this.hadLOS = this.hasLOS;
     this.setHasLOS();
 
@@ -219,17 +235,24 @@ export class JalZek extends Mob {
       return;
     }
 
-    const isUnderAggro = Collision.collisionMath(this.location.x, this.location.y, this.size, this.aggro.location.x, this.aggro.location.y, 1);
+    const isUnderAggro = Collision.collisionMath(
+      this.location.x,
+      this.location.y,
+      this.size,
+      this.aggro.location.x,
+      this.aggro.location.y,
+      1,
+    );
 
     if (!isUnderAggro && this.hasLOS) {
       // start flicker BEFORE initiating attack
       this.isFlickering = true;
       this.flickerTicksRemaining = this.flickerDurationTicks;
       //resetting visual state
-      this.extendedGltfModelInstance?.setFlickerVisualState(false); 
+      this.extendedGltfModelInstance?.setFlickerVisualState(false);
       // wait for flicker to finish before attacking
       this.attackDelay = this.flickerDurationTicks;
-      return; 
+      return;
     }
   }
 

--- a/src/content/inferno/js/mobs/JalZek.ts
+++ b/src/content/inferno/js/mobs/JalZek.ts
@@ -1,12 +1,13 @@
 "use strict";
 
-import { Assets, Mob, Projectile, MeleeWeapon, MagicWeapon, Sound, UnitBonuses, Collision, AttackIndicators, Random, Viewport, GLTFModel, EntityNames, Trainer } from "@supalosa/oldschool-trainer-sdk";
+import { Assets, Mob, Projectile, MeleeWeapon, MagicWeapon, Sound, UnitBonuses, Collision, AttackIndicators, Random, Viewport, GLTFModel, EntityNames, Trainer, Model } from "@supalosa/oldschool-trainer-sdk";
 
 import { InfernoMobDeathStore } from "../InfernoMobDeathStore";
 import { InfernoRegion } from "../InfernoRegion";
 
 import MagerImage from "../../assets/images/mager.png";
 import MagerSound from "../../assets/sounds/mage_ranger_598.ogg";
+import { JalZekModelWithLight } from "../JalZekModelWithLight";
 
 const HitSound = Assets.getAssetUrl("assets/sounds/dragon_hit_410.ogg");
 
@@ -15,6 +16,11 @@ export const MageProjectileModel = Assets.getAssetUrl("models/mage_projectile.gl
 
 export class JalZek extends Mob {
   shouldRespawnMobs: boolean;
+   isFlickering = false;
+   // flicker only the tick before the attack animation happns
+   flickerDurationTicks = 1; 
+   flickerTicksRemaining = 0;
+   extendedGltfModelInstance: JalZekModelWithLight | null = null;
 
   mobName() {
     return EntityNames.JAL_ZEK;
@@ -31,6 +37,10 @@ export class JalZek extends Mob {
   dead() {
     super.dead();
     InfernoMobDeathStore.npcDied(this);
+    if (this.isFlickering) {
+      this.isFlickering = false;
+      this.updateUnderglowVisuals();
+    }
   }
 
   setStats() {
@@ -143,57 +153,84 @@ export class JalZek extends Mob {
     return { x: 21, y: 22 };
   }
 
-  attackIfPossible() {
-    this.attackStyle = this.attackStyleForNewAttack();
-
-    this.attackFeedback = AttackIndicators.NONE;
-
-    this.hadLOS = this.hasLOS;
-    this.setHasLOS();
-
-    if (!this.aggro || this.canAttack() === false) {
-      return;
+   create3dModel() {
+    if (!this.extendedGltfModelInstance) {
+      this.extendedGltfModelInstance = new JalZekModelWithLight(this, MagerModel);
     }
+    return this.extendedGltfModelInstance;
+  }
 
-    const isUnderAggro = Collision.collisionMath(
-      this.location.x,
-      this.location.y,
-      this.size,
-      this.aggro.location.x,
-      this.aggro.location.y,
-      1,
-    );
-
-    if (!isUnderAggro && this.hasLOS && this.attackDelay <= 0) {
-      if (Random.get() < 0.1 && !this.shouldRespawnMobs) {
-        const mobToResurrect = InfernoMobDeathStore.selectMobToResurect(this.region);
-        if (!mobToResurrect) {
-          this.attack() && this.didAttack();
-        } else {
-          // Set to 50% health
-          mobToResurrect.currentStats.hitpoint = Math.floor(mobToResurrect.stats.hitpoint / 2);
-          mobToResurrect.dying = -1;
-          mobToResurrect.attackDelay = mobToResurrect.attackSpeed;
-
-          mobToResurrect.setLocation(this.respawnLocation(mobToResurrect));
-          mobToResurrect.playAnimation(mobToResurrect.idlePoseId);
-          mobToResurrect.cancelDeath();
-          mobToResurrect.aggro = Trainer.player;
-
-          mobToResurrect.perceivedLocation = mobToResurrect.location;
-          this.region.addMob(mobToResurrect);
-          // (15, 10) to  (21 , 22
-          this.attackDelay = 8;
-          this.playAnimation(3);
-        }
-      } else {
-        this.attack() && this.didAttack();
-      }
+   updateUnderglowVisuals() {
+    if (this.extendedGltfModelInstance) {
+      this.extendedGltfModelInstance.setFlickerVisualState(this.isFlickering);
     }
   }
 
-  create3dModel() {
-    return GLTFModel.forRenderable(this, MagerModel);
+   attackStep() {
+    super.attackStep();
+
+    if (this.isFlickering) {
+      this.flickerTicksRemaining--;
+      // double flicker on the flicker tick
+      this.extendedGltfModelInstance?.setFlickerVisualState(true); 
+      if (this.flickerTicksRemaining <= 0) {
+        this.isFlickering = false;
+        // reset to normal
+        this.extendedGltfModelInstance?.setFlickerVisualState(false); 
+        // Set attack style before attacking
+        this.attackStyle = this.attackStyleForNewAttack();
+        this.attackFeedback = AttackIndicators.NONE;
+        if (Random.get() < 0.1 && !this.shouldRespawnMobs) {
+          const mobToResurrect = InfernoMobDeathStore.selectMobToResurect(this.region);
+          if (!mobToResurrect) {
+            this.attack() && this.didAttack();
+          } else {
+            // Set to 50% health
+            mobToResurrect.currentStats.hitpoint = Math.floor(mobToResurrect.stats.hitpoint / 2);
+            mobToResurrect.dying = -1;
+            mobToResurrect.attackDelay = mobToResurrect.attackSpeed;
+
+            mobToResurrect.setLocation(this.respawnLocation(mobToResurrect));
+            mobToResurrect.playAnimation(mobToResurrect.idlePoseId);
+            mobToResurrect.cancelDeath();
+            mobToResurrect.aggro = Trainer.player;
+
+            mobToResurrect.perceivedLocation = mobToResurrect.location;
+            this.region.addMob(mobToResurrect);
+            // (15, 10) to  (21 , 22
+            this.attackDelay = 8;
+            this.playAnimation(3);
+          }
+        } else {
+          this.attack() && this.didAttack();
+        }
+        this.attackDelay = this.attackSpeed;
+      }
+      return;
+    }
+    this.attackIfPossible();
+  }
+
+   attackIfPossible() {
+    this.hadLOS = this.hasLOS;
+    this.setHasLOS();
+
+    if (!this.aggro || this.stunned > 0 || this.frozen > 0 || this.attackDelay > 0 || this.isDying()) {
+      return;
+    }
+
+    const isUnderAggro = Collision.collisionMath(this.location.x, this.location.y, this.size, this.aggro.location.x, this.aggro.location.y, 1);
+
+    if (!isUnderAggro && this.hasLOS) {
+      // start flicker BEFORE initiating attack
+      this.isFlickering = true;
+      this.flickerTicksRemaining = this.flickerDurationTicks;
+      //resetting visual state
+      this.extendedGltfModelInstance?.setFlickerVisualState(false); 
+      // wait for flicker to finish before attacking
+      this.attackDelay = this.flickerDurationTicks;
+      return; 
+    }
   }
 
   override get attackAnimationId() {


### PR DESCRIPTION
Added a visual "flicker" effect for the JalZek NPC, which occurs right before it starts it's attack animation (wthout changing the SDK code, yay).

**Small key changes**:
Added flickering state management in the JalZek class:
New props to track flickering state and duration
Integration with the existing attack cycle (it appears the existing logic works at the moment)

For the new file created:
Instead of trying to modify the model after it is loaded, I extended the GLTFModel class.
I used the https://github.com/Supalosa/InfernoTrainer/blob/colosseum/src/content/colosseum/js/rendering/GroundSlamModel.ts for reference, since the main challenge being that I needed to attach a light to the 3D model without being able to directly access the model's scene graph after it was loaded.

The light is a THREE.PointLight attached to the model during the "draw" cycle.
We can change the intensity etc as needed.

